### PR TITLE
Change EntityPlayer ASM code for Java 21+ compat

### DIFF
--- a/src/main/java/zmaster587/advancedRocketry/asm/ClassTransformer.java
+++ b/src/main/java/zmaster587/advancedRocketry/asm/ClassTransformer.java
@@ -686,20 +686,17 @@ public class ClassTransformer implements IClassTransformer {
                 LabelNode label = new LabelNode();
                 AbstractInsnNode pos;
                 AbstractInsnNode ain = null;
-                int numSpec = 1;
-                int numAload = 7;
 
                 for (int i = 0; i < onUpdate.instructions.size(); i++) {
                     ain = onUpdate.instructions.get(i);
-                    if (ain.getOpcode() == Opcodes.INVOKESPECIAL && numSpec-- == 0) {
-
+                    if (ain.getOpcode() == Opcodes.GETFIELD && ((FieldInsnNode) ain).name.equals(obf ? "by" : "openContainer")) {
+                        ain = ain.getPrevious();
                         while (i < onUpdate.instructions.size()) {
                             pos = onUpdate.instructions.get(i++);
-                            if (pos.getOpcode() == Opcodes.ALOAD && numAload-- == 0) {
-                                label = (LabelNode) pos.getPrevious().getPrevious().getPrevious();
+                            if (pos.getOpcode() == Opcodes.PUTFIELD && ((FieldInsnNode) pos).name.equals(obf ? "by" : "openContainer")) {
+                                label = (LabelNode) pos.getNext();
                                 break;
                             }
-
                         }
                         break;
                     }
@@ -711,7 +708,7 @@ public class ClassTransformer implements IClassTransformer {
                 nodeAdd.add(new MethodInsnNode(Opcodes.INVOKESTATIC, "zmaster587/advancedRocketry/util/RocketInventoryHelper", "allowAccess", "(Ljava/lang/Object;)Z", false));
                 nodeAdd.add(new JumpInsnNode(Opcodes.IFEQ, label));
 
-                onUpdate.instructions.insert(ain, nodeAdd);
+                onUpdate.instructions.insertBefore(ain, nodeAdd);
 
                 //onUpdate.instructions.insertBefore(pos, label);
 


### PR DESCRIPTION
Previous method was counting InvokeSpecial instructions, which break in Java 11+ because one of the instructions (`EntityPlayer#isInBed`) is instead compiled as an InvokeVirutal (See [related question](https://stackoverflow.com/questions/67226178/why-does-the-java-compiler-11-use-invokevirtual-to-call-private-methods)). 
Fugue (a mod for Java 21+/Cleanroom to fix other mods) patches the AR transformer by looking for a specific `LineNumberNode`, but line numbers don't match between original AR and this fork. So this PR changes the way the position to inject code is found.

Slightly changes the injection point of the code, but should be functionally equivalent.
Original AR:
```
if (RocketInventoryHelper.allowAccess(this) &&
    !this.world.isRemote &&
    this.openContainer != null && 
    !this.openContainer.canInteractWith(this))
```
This PR:
```
if (!this.world.isRemote &&
    RocketInventoryHelper.allowAccess(this) &&
    this.openContainer != null &&
    !this.openContainer.canInteractWith(this))
```

`Enable Advanced Rocketry Patch` in `fugue.cfg` must be `false` until CleanroomMC/Fugue#58 is merged.
Fixes #27.