### PR TITLE
matter overdrive integration

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -159,6 +159,7 @@ dependencies {
     //runtimeOnly(fg.deobf("mezz.jei:jei_${mcVersion}:${jeiVersion}")) // I think this crashes the game for me when running from IntelliJ
 
     implementation(fileTree(mapOf("dir" to "libs", "include" to listOf("*.jar"))))
+    compileOnly(fileTree(mapOf("dir" to "libs/compileOnly", "include" to listOf("*.jar"))))
 
     implementation ("net.minecraftforge:mergetool:0.2.3.3")
 }

--- a/src/main/java/zmaster587/advancedRocketry/atmosphere/AtmosphereNeedsSuit.java
+++ b/src/main/java/zmaster587/advancedRocketry/atmosphere/AtmosphereNeedsSuit.java
@@ -1,6 +1,7 @@
 package zmaster587.advancedRocketry.atmosphere;
 
 import matteroverdrive.entity.player.MOPlayerCapabilityProvider;
+import matteroverdrive.init.OverdriveBioticStats;
 import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.inventory.EntityEquipmentSlot;
@@ -28,7 +29,9 @@ public class AtmosphereNeedsSuit extends AtmosphereType {
     public boolean isImmune(EntityLivingBase player) {
 
         if(Loader.isModLoaded("matteroverdrive")) {
-            return (MOPlayerCapabilityProvider.GetAndroidCapability(player) != null && MOPlayerCapabilityProvider.GetAndroidCapability(player).isAndroid());
+            if (MOPlayerCapabilityProvider.GetAndroidCapability(player) != null
+                    && MOPlayerCapabilityProvider.GetAndroidCapability(player).isAndroid()
+                    && MOPlayerCapabilityProvider.GetAndroidCapability(player).isUnlocked(OverdriveBioticStats.oxygen, 1)) return true;
         }
         //Checks if player is wearing spacesuit or anything that extends ItemSpaceArmor
 

--- a/src/main/java/zmaster587/advancedRocketry/atmosphere/AtmosphereNeedsSuit.java
+++ b/src/main/java/zmaster587/advancedRocketry/atmosphere/AtmosphereNeedsSuit.java
@@ -1,9 +1,11 @@
 package zmaster587.advancedRocketry.atmosphere;
 
+import matteroverdrive.entity.player.MOPlayerCapabilityProvider;
 import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.inventory.EntityEquipmentSlot;
 import net.minecraft.item.ItemStack;
+import net.minecraftforge.fml.common.Loader;
 import zmaster587.advancedRocketry.api.EntityRocketBase;
 import zmaster587.advancedRocketry.api.capability.CapabilitySpaceArmor;
 import zmaster587.advancedRocketry.entity.EntityElevatorCapsule;
@@ -25,7 +27,9 @@ public class AtmosphereNeedsSuit extends AtmosphereType {
     @Override
     public boolean isImmune(EntityLivingBase player) {
 
-
+        if(Loader.isModLoaded("matteroverdrive")) {
+            return (MOPlayerCapabilityProvider.GetAndroidCapability(player) != null && MOPlayerCapabilityProvider.GetAndroidCapability(player).isAndroid());
+        }
         //Checks if player is wearing spacesuit or anything that extends ItemSpaceArmor
 
         ItemStack feet = player.getItemStackFromSlot(EntityEquipmentSlot.FEET);


### PR DESCRIPTION
just turning off atmosphere impact if player turned into android and unlocked ability that allows to live without oxygen